### PR TITLE
Support User Timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Start the application in development mode with:
 make && ./bin/guess-my-word
 ```
 
-Then view the website at http://127.0.0.1.
+Then view the website at http://127.0.0.1:3000.
 
 Dev away!
 

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1,6 +1,8 @@
 package actions
 
 import (
+	"context"
+	"guess_my_word/internal/words"
 	"html/template"
 	"io/ioutil"
 	"os"
@@ -11,8 +13,17 @@ import (
 	"github.com/markbates/pkger"
 )
 
+type wordClient interface {
+	Validate(context.Context, string) bool
+	GetForDay(context.Context, time.Time, string) (string, error)
+}
+
+var wordStore wordClient
+
 // AddHandlers will add the application handlers to the HTTP server
 func AddHandlers(r *gin.Engine) {
+	wordStore = words.NewWordStore()
+
 	if gin.IsDebugging() {
 		addHandlersStaticPreProduction(r)
 	} else {

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/markbates/pkger"
@@ -20,6 +21,7 @@ func AddHandlers(r *gin.Engine) {
 
 	r.Use(middlewareStandardHeaders())
 	r.GET("/", HomeHandler)
+	r.GET("/reveal", RevealHandler)
 	r.GET("/ping", PingHandler)
 	r.GET("/guess", GuessHandler)
 	r.GET("/hint", HintHandler)
@@ -73,4 +75,12 @@ func addHandlersStaticProduction(r *gin.Engine) {
 func addHandlersStaticPreProduction(r *gin.Engine) {
 	r.LoadHTMLGlob("templates/*")
 	r.Static("/assets", "./assets")
+}
+
+// convertUTCToLocal will take a given time in UTC and convert it to a given user's timezone
+// TZ for PDT (-7:00) is a positive 420, so SUBTRACT that from the unix timestamp
+func convertUTCToUser(t time.Time, tz int) time.Time {
+	ret := t.In(time.FixedZone("User", tz*-1))
+	ret = ret.Add(time.Minute * -1 * time.Duration(tz))
+	return ret
 }

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1,8 +1,23 @@
 package actions
 
 import (
+	"context"
+	"time"
+
 	"github.com/gin-gonic/gin"
 )
+
+type mockWordStore struct {
+	mockValidate  func(context.Context, string) bool
+	mockGetForDay func(context.Context, time.Time, string) (string, error)
+}
+
+func (m *mockWordStore) Validate(ctx context.Context, word string) bool {
+	return m.mockValidate(ctx, word)
+}
+func (m *mockWordStore) GetForDay(ctx context.Context, tm time.Time, mode string) (string, error) {
+	return m.mockGetForDay(ctx, tm, mode)
+}
 
 func setupRouter() *gin.Engine {
 	gin.SetMode(gin.TestMode)

--- a/actions/guess.go
+++ b/actions/guess.go
@@ -13,6 +13,7 @@ type guess struct {
 	Word  string    `form:"word"`
 	Mode  string    `form:"mode"`
 	Start time.Time `form:"start" time_format:"unix"`
+	TZ    int       `form:"tz"`
 }
 
 type guessReply struct {
@@ -29,6 +30,9 @@ const (
 
 	// ErrInvalidStartTime is emitted when the start time is malformed or invalid
 	ErrInvalidStartTime = "Invalid start time provided with request"
+
+	// ErrInvalidTimezone is emitted when the timezone is malformed or invalid
+	ErrInvalidTimezone = "Invalid timezone provided with request"
 
 	// ErrEmptyGuess is emitted when the guess provided was empty
 	ErrEmptyGuess = "Guess must not be empty"
@@ -57,8 +61,7 @@ func GuessHandler(c *gin.Context) {
 	}
 
 	// Generate the word for the day
-	guess.Start = guess.Start.UTC()
-	word, err := words.GetForDay(c, guess.Start, guess.Mode)
+	word, err := words.GetForDay(c, convertUTCToUser(guess.Start, guess.TZ), guess.Mode)
 	if err != nil {
 		reply.Error = err.Error()
 		c.JSON(500, reply)

--- a/actions/guess.go
+++ b/actions/guess.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"guess_my_word/internal/words"
 	"log"
 	"strings"
 	"time"
@@ -49,7 +48,7 @@ func GuessHandler(c *gin.Context) {
 		reply.Error = ErrInvalidRequest
 	} else if len(strings.TrimSpace(guess.Word)) == 0 {
 		reply.Error = ErrEmptyGuess
-	} else if !words.Validate(c, guess.Word) {
+	} else if !wordStore.Validate(c, guess.Word) {
 		reply.Error = ErrInvalidWord
 	} else if guess.Start.Unix() == 0 {
 		reply.Error = ErrInvalidStartTime
@@ -61,7 +60,7 @@ func GuessHandler(c *gin.Context) {
 	}
 
 	// Generate the word for the day
-	word, err := words.GetForDay(c, convertUTCToUser(guess.Start, guess.TZ), guess.Mode)
+	word, err := wordStore.GetForDay(c, convertUTCToUser(guess.Start, guess.TZ), guess.Mode)
 	if err != nil {
 		reply.Error = err.Error()
 		c.JSON(500, reply)

--- a/actions/hint.go
+++ b/actions/hint.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"guess_my_word/internal/words"
 	"log"
 	"strings"
 	"time"
@@ -50,7 +49,7 @@ func HintHandler(c *gin.Context) {
 	}
 
 	// Generate the word for the day
-	word, err := words.GetForDay(c, convertUTCToUser(hint.Start, hint.TZ), hint.Mode)
+	word, err := wordStore.GetForDay(c, convertUTCToUser(hint.Start, hint.TZ), hint.Mode)
 	if err != nil {
 		reply.Error = err.Error()
 		c.JSON(500, reply)

--- a/actions/hint.go
+++ b/actions/hint.go
@@ -14,6 +14,7 @@ type hint struct {
 	Before string    `form:"before"`
 	Mode   string    `form:"mode"`
 	Start  time.Time `form:"start" time_format:"unix"`
+	TZ     int       `form:"tz"`
 }
 
 type hintReply struct {
@@ -49,8 +50,7 @@ func HintHandler(c *gin.Context) {
 	}
 
 	// Generate the word for the day
-	hint.Start = hint.Start.UTC()
-	word, err := words.GetForDay(c, hint.Start, hint.Mode)
+	word, err := words.GetForDay(c, convertUTCToUser(hint.Start, hint.TZ), hint.Mode)
 	if err != nil {
 		reply.Error = err.Error()
 		c.JSON(500, reply)

--- a/actions/home.go
+++ b/actions/home.go
@@ -1,9 +1,7 @@
 package actions
 
 import (
-	"guess_my_word/internal/words"
 	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -15,12 +13,8 @@ func HomeHandler(c *gin.Context) {
 		mode = "default"
 	}
 
-	tm := time.Now().UTC().AddDate(0, 0, -1)
-	yesterday, _ := words.GetForDay(c, tm, mode)
-
 	c.HTML(200, "index.html", gin.H{
-		"debug":     gin.IsDebugging(),
-		"mode":      mode,
-		"yesterday": yesterday,
+		"debug": gin.IsDebugging(),
+		"mode":  mode,
 	})
 }

--- a/actions/ping_test.go
+++ b/actions/ping_test.go
@@ -1,0 +1,20 @@
+package actions
+
+import (
+	"testing"
+
+	"net/http"
+	"net/http/httptest"
+)
+
+func Test_PingHandler(t *testing.T) {
+	router := setupRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/ping", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Body.String() != "pong" {
+		t.Error("Output did not contain pong")
+	}
+}

--- a/actions/reveal.go
+++ b/actions/reveal.go
@@ -1,0 +1,66 @@
+package actions
+
+import (
+	"guess_my_word/internal/words"
+	"log"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type reveal struct {
+	Date     time.Time `form:"date" time_format:"unix"` // The unix date, no timestamp
+	dateUser time.Time // The date under the user's timezone
+	TZ       int       `form:"tz"`
+	Mode     string    `form:"mode"`
+}
+
+type revealReply struct {
+	Word  string `json:"word"`
+	Error string `json:"error"`
+}
+
+// ErrRevealToday is emitted when the reveal request is for a current or future word
+const ErrRevealToday = "It's too early to reveal this word. Please try again later!"
+
+// RevealHandler reveals the word for a given day
+// ...but not today :)
+func RevealHandler(c *gin.Context) {
+	reveal := reveal{}
+	reply := revealReply{}
+
+	// Validate the reveal
+	if err := c.ShouldBind(&reveal); err != nil {
+		log.Println("Invalid request received: ", err)
+		reply.Error = ErrInvalidRequest
+	} else if reveal.Date.Unix() == 0 {
+		reply.Error = ErrInvalidStartTime
+	} else {
+		reveal.dateUser = convertUTCToUser(reveal.Date, reveal.TZ)
+		log.Printf("Requested date is: %s", reveal.dateUser)
+
+		y, m, d := time.Now().Date()
+		cmp := time.Date(y, m, d, 0, 0, 0, 0, reveal.dateUser.Location())
+
+		if reveal.dateUser.After(cmp) {
+			log.Printf("Compared date was: %s", reveal.dateUser)
+			reply.Error = ErrRevealToday
+		}
+	}
+
+	if reply.Error != "" {
+		c.JSON(200, reply)
+		return
+	}
+
+	// Generate the word for the day
+	word, err := words.GetForDay(c, reveal.dateUser, reveal.Mode)
+	if err != nil {
+		reply.Error = err.Error()
+		c.JSON(500, reply)
+		return
+	}
+
+	reply.Word = word
+	c.JSON(200, reply)
+}

--- a/actions/reveal.go
+++ b/actions/reveal.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"guess_my_word/internal/words"
 	"log"
 	"time"
 
@@ -54,7 +53,7 @@ func RevealHandler(c *gin.Context) {
 	}
 
 	// Generate the word for the day
-	word, err := words.GetForDay(c, reveal.dateUser, reveal.Mode)
+	word, err := wordStore.GetForDay(c, reveal.dateUser, reveal.Mode)
 	if err != nil {
 		reply.Error = err.Error()
 		c.JSON(500, reply)

--- a/actions/reveal_test.go
+++ b/actions/reveal_test.go
@@ -1,0 +1,103 @@
+package actions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRevealHandler(t *testing.T) {
+	type args struct {
+		request string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		mockGetForDay func(ctx context.Context, tm time.Time, mode string) (string, error)
+		want          revealReply
+		wantCode      int
+	}{
+		{
+			name: "success",
+			mockGetForDay: func(ctx context.Context, tm time.Time, mode string) (string, error) {
+				return "theword", nil
+			},
+			args: args{
+				request: "/reveal",
+			},
+			want:     revealReply{Word: "theword"},
+			wantCode: 200,
+		},
+		{
+			name: "error-invalid-request",
+			mockGetForDay: func(ctx context.Context, tm time.Time, mode string) (string, error) {
+				return "theword", nil
+			},
+			args: args{
+				request: "/reveal?date=notAValidUnixTimestamp",
+			},
+			want:     revealReply{Error: ErrInvalidRequest},
+			wantCode: 200,
+		},
+		{
+			name: "error-invalid-date",
+			mockGetForDay: func(ctx context.Context, tm time.Time, mode string) (string, error) {
+				return "theword", nil
+			},
+			args: args{
+				request: "/reveal?date=0",
+			},
+			want:     revealReply{Error: ErrInvalidStartTime},
+			wantCode: 200,
+		},
+		{
+			name: "error-too-early",
+			mockGetForDay: func(ctx context.Context, tm time.Time, mode string) (string, error) {
+				return "theword", nil
+			},
+			args: args{
+				request: fmt.Sprintf("/reveal?date=%d", time.Now().AddDate(0, 0, 1).Unix()),
+			},
+			want:     revealReply{Error: ErrRevealToday},
+			wantCode: 200,
+		},
+		{
+			name: "error-getword",
+			mockGetForDay: func(ctx context.Context, tm time.Time, mode string) (string, error) {
+				return "", errors.New("ohnoes")
+			},
+			args: args{
+				request: "/reveal",
+			},
+			want:     revealReply{Error: "ohnoes"},
+			wantCode: 500,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := setupRouter()
+			wordStore = &mockWordStore{
+				mockGetForDay: tt.mockGetForDay,
+			}
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", tt.args.request, nil)
+			router.ServeHTTP(w, req)
+
+			var response revealReply
+			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+				t.Error("Unable to unmarshal response body: ", w.Body.String())
+			} else if w.Code != tt.wantCode {
+				t.Errorf("Response Code = %d; wantCode %d", w.Code, tt.wantCode)
+			} else if !reflect.DeepEqual(response, tt.want) {
+				t.Errorf("Response = %#v; want %#v", response, tt.want)
+			}
+		})
+	}
+}

--- a/internal/words/words.go
+++ b/internal/words/words.go
@@ -9,6 +9,11 @@ import (
 )
 
 type (
+	// WordStore will generate and validate words
+	WordStore struct {
+		storeClient Store
+	}
+
 	// Word defines information about a given key's word
 	Word struct {
 		Value string
@@ -22,37 +27,38 @@ type (
 )
 
 var (
-	// storeClient contains the internal datastore client
-	storeClient Store
-
 	// words were taken from the original inspiration for this app, https://hryanjones.com/guess-my-word/
 	// That project took the words from 1-1,000 common English words on TV and movies https://en.wiktionary.org/wiki/Wiktionary:Frequency_lists/TV/2006/1-1000
 	words []string = []string{"course", "against", "ready", "daughter", "work", "friends", "minute", "though", "supposed", "honey", "point", "start", "check", "alone", "matter", "office", "hospital", "three", "already", "anyway", "important", "tomorrow", "almost", "later", "found", "trouble", "excuse", "hello", "money", "different", "between", "every", "party", "either", "enough", "year", "house", "story", "crazy", "mind", "break", "tonight", "person", "sister", "pretty", "trust", "funny", "gift", "change", "business", "train", "under", "close", "reason", "today", "beautiful", "brother", "since", "bank", "yourself", "without", "until", "forget", "anyone", "promise", "happy", "bake", "worry", "school", "afraid", "cause", "doctor", "exactly", "second", "phone", "look", "feel", "somebody", "stuff", "elephant", "morning", "heard", "world", "chance", "call", "watch", "whatever", "perfect", "dinner", "family", "heart", "least", "answer", "woman", "bring", "probably", "question", "stand", "truth", "problem", "patch", "pass", "famous", "true", "power", "cool", "last", "fish", "remote", "race", "noon", "wipe", "grow", "jumbo", "learn", "itself", "chip", "print", "young", "argue", "clean", "remove", "flip", "flew", "replace", "kangaroo", "side", "walk", "gate", "finger", "target", "judge", "push", "thought", "wear", "desert", "relief", "basic", "bright", "deal", "father", "machine", "know", "step", "exercise", "present", "wing", "lake", "beach", "ship", "wait", "fancy", "eight", "hall", "rise", "river", "round", "girl", "winter", "speed", "long", "oldest", "lock", "kiss", "lava", "garden", "fight", "hook", "desk", "test", "serious", "exit", "branch", "keyboard", "naked", "science", "trade", "quiet", "home", "prison", "blue", "window", "whose", "spot", "hike", "laptop", "dark", "create", "quick", "face", "freeze", "plug", "menu", "terrible", "accept", "door", "touch", "care", "rescue", "ignore", "real", "title", "city", "fast", "season", "town", "picture", "tower", "zero", "engine", "lift", "respect", "time", "mission", "play", "discover", "nail", "half", "unusual", "ball", "tool", "heavy", "night", "farm", "firm", "gone", "help", "easy", "library", "group", "jungle", "taste", "large", "imagine", "normal", "outside", "paper", "nose", "long", "queen", "olive", "doing", "moon", "hour", "protect", "hate", "dead", "double", "nothing", "restaurant", "reach", "note", "tell", "baby", "future", "tall", "drop", "speak", "rule", "pair", "ride", "ticket", "game", "hair", "hurt", "allow", "oven", "live", "horse", "bottle", "rock", "public", "find", "garage", "green", "heat", "plan", "mean", "little", "spend", "nurse", "practice", "wish", "uncle", "core", "stop", "number", "nest", "magazine", "pool", "message", "active", "throw", "pull", "level", "wrist", "bubble", "hold", "movie", "huge", "ketchup", "finish", "pilot", "teeth", "flag", "head", "private", "together", "jewel", "child", "decide", "listen", "garbage", "jealous", "wide", "straight", "fall", "joke", "table", "spread", "laundry", "deep", "quit", "save", "worst", "email", "glass", "scale", "safe", "path", "camera", "excellent", "place", "zone", "luck", "tank", "sign", "report", "myself", "knee", "need", "root", "light", "sure", "page", "life", "space", "magic", "size", "tape", "food", "wire", "period", "mistake", "full", "paid", "horrible", "special", "hidden", "rain", "field", "kick", "ground", "screen", "risky", "junk", "juice", "human", "nobody", "mall", "bathroom", "high", "class", "street", "cold", "metal", "nervous", "bike", "internet", "wind", "lion", "summer", "president", "empty", "square", "jersey", "worm", "popular", "loud", "online", "something", "photo", "knot", "mark", "zebra", "road", "storm", "grab", "record", "said", "floor", "theater", "kitchen", "action", "equal", "nice", "dream", "sound", "fifth", "comfy", "talk", "police", "draw", "bunch", "idea", "jerk", "copy", "success", "team", "favor", "open", "neat", "whale", "gold", "free", "mile", "lying", "meat", "nine", "wonderful", "hero", "quilt", "info", "radio", "move", "early", "remember", "understand", "month", "everyone", "quarter", "center", "universe", "name", "zoom", "inside", "label", "yell", "jacket", "nation", "support", "lunch", "twice", "hint", "jiggle", "boot", "alive", "build", "date", "room", "fire", "music", "leader", "rest", "plant", "connect", "land", "body", "belong", "trick", "wild", "quality", "band", "health", "website", "love", "hand", "okay", "yeah", "dozen", "glove", "give", "thick", "flow", "project", "tight", "join", "cost", "trip", "lower", "magnet", "parent", "grade", "angry", "line", "rich", "owner", "block", "shut", "neck", "write", "hotel", "danger", "impossible", "illegal", "show", "come", "want", "truck", "click", "chocolate", "none", "done", "bone", "hope", "share", "cable", "leaf", "water", "teacher", "dust", "orange", "handle", "unhappy", "guess", "past", "frame", "knob", "winner", "ugly", "lesson", "bear", "gross", "midnight", "grass", "middle", "birthday", "rose", "useless", "hole", "drive", "loop", "color", "sell", "unfair", "send", "crash", "knife", "wrong", "guest", "strong", "weather", "kilometer", "undo", "catch", "neighbor", "stream", "random", "continue", "return", "begin", "kitten", "thin", "pick", "whole", "useful", "rush", "mine", "toilet", "enter", "wedding", "wood", "meet", "stolen", "hungry", "card", "fair", "crowd", "glow", "ocean", "peace", "match", "hill", "welcome", "across", "drag", "island", "edge", "great", "unlock", "feet", "iron", "wall", "laser", "fill", "boat", "weird", "hard", "happen", "tiny", "event", "math", "robot", "recently", "seven", "tree", "rough", "secret", "nature", "short", "mail", "inch", "raise", "warm", "gentle", "glue", "roll", "search", "regular", "here", "count", "hunt", "keep", "week"}
 )
 
-func init() {
-	storeClient = datastore.New()
+// NewWordStore will return an instance of the word generator
+func NewWordStore() *WordStore {
+	return &WordStore{
+		storeClient: datastore.New(),
+	}
 }
 
 // GetForDay will return a word for the given day
-func GetForDay(ctx context.Context, tm time.Time, mode string) (string, error) {
+// This func is timezone agnostic. It will only consider the current local date
+func (w *WordStore) GetForDay(ctx context.Context, tm time.Time, mode string) (string, error) {
 	key := mode + "/day/" + tm.Format("2006-01-02")
 	log.Println("Getting word for day at ", key)
 
 	// Grab the word from the datastore
 	word := Word{}
-	err := storeClient.GetWord(ctx, key, &word)
+	err := w.storeClient.GetWord(ctx, key, &word)
 	if err != nil {
 		// Generate a new word
 		log.Printf("Encountered error '%s'. Generating new word for key '%s'", err, key)
-		word.Value, err = generateWord(tm, getWordList(mode))
+		word.Value, err = w.generateWord(tm, w.getWordList(mode))
 		if err != nil {
 			return word.Value, err
 		}
 
 		// And store it
 		log.Printf("Storing generated word '%s' at key '%s'", word.Value, key)
-		err = storeClient.SetWord(ctx, key, word)
+		err = w.storeClient.SetWord(ctx, key, word)
 		if err != nil {
 			log.Printf("Encountered error storing new word '%s' at key '%s': %s", word.Value, key, err)
 		}
@@ -62,7 +68,7 @@ func GetForDay(ctx context.Context, tm time.Time, mode string) (string, error) {
 }
 
 // Validate will confirm if a given word is valid
-func Validate(ctx context.Context, word string) bool {
+func (w *WordStore) Validate(ctx context.Context, word string) bool {
 	for _, line := range scrabble {
 		if line == word {
 			return true
@@ -72,14 +78,14 @@ func Validate(ctx context.Context, word string) bool {
 	return false
 }
 
-func generateWord(seed time.Time, words []string) (string, error) {
+func (w *WordStore) generateWord(seed time.Time, words []string) (string, error) {
 	if seed.Unix() == 0 {
 		return "", fmt.Errorf("Invalid timestamp for word")
 	}
 	return words[(seed.Year()*seed.YearDay())%len(words)], nil
 }
 
-func getWordList(mode string) []string {
+func (w *WordStore) getWordList(mode string) []string {
 	switch mode {
 	case "hard":
 		return scrabble

--- a/internal/words/words.go
+++ b/internal/words/words.go
@@ -76,9 +76,7 @@ func generateWord(seed time.Time, words []string) (string, error) {
 	if seed.Unix() == 0 {
 		return "", fmt.Errorf("Invalid timestamp for word")
 	}
-
-	day := seed.UTC()
-	return words[(day.Year()*day.YearDay())%len(words)], nil
+	return words[(seed.Year()*seed.YearDay())%len(words)], nil
 }
 
 func getWordList(mode string) []string {

--- a/internal/words/words_test.go
+++ b/internal/words/words_test.go
@@ -16,11 +16,10 @@ func (m *mockStore) SetWord(ctx context.Context, key string, word interface{}) e
 	return nil
 }
 
-func init() {
-	storeClient = &mockStore{}
-}
-
-func TestGetForDay(t *testing.T) {
+func TestWordStore_GetForDay(t *testing.T) {
+	type fields struct {
+		storeClient Store
+	}
 	type args struct {
 		ctx  context.Context
 		tm   time.Time
@@ -28,12 +27,14 @@ func TestGetForDay(t *testing.T) {
 	}
 	tests := []struct {
 		name    string
+		fields  fields
 		args    args
 		want    string
 		wantErr bool
 	}{
 		{
-			name: "Date yesterday",
+			name:   "Date yesterday",
+			fields: fields{storeClient: &mockStore{}},
 			args: args{
 				ctx:  context.Background(),
 				tm:   time.Date(2020, time.January, 26, 2, 0, 0, 0, time.UTC),
@@ -42,7 +43,8 @@ func TestGetForDay(t *testing.T) {
 			want: "power",
 		},
 		{
-			name: "Date tweak yesterday",
+			name:   "Date tweak yesterday",
+			fields: fields{storeClient: &mockStore{}},
 			args: args{
 				ctx:  context.Background(),
 				tm:   time.Date(2020, time.January, 27, 2, 0, 0, 0, time.UTC).UTC().AddDate(0, 0, -1),
@@ -51,7 +53,8 @@ func TestGetForDay(t *testing.T) {
 			want: "power",
 		},
 		{
-			name: "Unix yesterday",
+			name:   "Unix yesterday",
+			fields: fields{storeClient: &mockStore{}},
 			args: args{
 				ctx:  context.Background(),
 				tm:   time.Unix(1580083199, 0), // Sun Jan 26 23:59:59 2020 UTC
@@ -60,7 +63,8 @@ func TestGetForDay(t *testing.T) {
 			want: "power",
 		},
 		{
-			name: "Date today",
+			name:   "Date today",
+			fields: fields{storeClient: &mockStore{}},
 			args: args{
 				ctx:  context.Background(),
 				tm:   time.Date(2020, time.January, 27, 2, 0, 0, 0, time.UTC),
@@ -69,7 +73,24 @@ func TestGetForDay(t *testing.T) {
 			want: "tell",
 		},
 		{
-			name: "Date tweak today",
+			name:   "Date today TZ",
+			fields: fields{storeClient: &mockStore{}},
+			args: args{
+				ctx: context.Background(),
+				tm: time.Date(2020, time.January, 27, 2, 0, 0, 0, func() *time.Location {
+					ret, err := time.LoadLocation("America/Los_Angeles")
+					if err != nil {
+						t.Fatal("Test machine timezone data not populated")
+					}
+					return ret
+				}()),
+				mode: "default",
+			},
+			want: "tell",
+		},
+		{
+			name:   "Date tweak today",
+			fields: fields{storeClient: &mockStore{}},
 			args: args{
 				ctx:  context.Background(),
 				tm:   time.Date(2020, time.January, 26, 2, 0, 0, 0, time.UTC).UTC().AddDate(0, 0, 1),
@@ -78,16 +99,18 @@ func TestGetForDay(t *testing.T) {
 			want: "tell",
 		},
 		{
-			name: "Unix today",
+			name:   "Unix today",
+			fields: fields{storeClient: &mockStore{}},
 			args: args{
 				ctx:  context.Background(),
 				tm:   time.Unix(1580083201, 0), // Mon Jan 27 00:00:01 2020 UTC
 				mode: "default",
 			},
-			want: "tell",
+			want: "power",
 		},
 		{
-			name: "Hard mode date today",
+			name:   "Hard mode date today",
+			fields: fields{storeClient: &mockStore{}},
 			args: args{
 				ctx:  context.Background(),
 				tm:   time.Date(2020, time.January, 27, 2, 0, 0, 0, time.UTC),
@@ -96,7 +119,8 @@ func TestGetForDay(t *testing.T) {
 			want: "damans",
 		},
 		{
-			name: "Unix OMG ERROR",
+			name:   "Unix OMG ERROR",
+			fields: fields{storeClient: &mockStore{}},
 			args: args{
 				ctx:  context.Background(),
 				tm:   time.Unix(0, 0),
@@ -108,7 +132,11 @@ func TestGetForDay(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetForDay(tt.args.ctx, tt.args.tm, tt.args.mode)
+			w := &WordStore{
+				storeClient: tt.fields.storeClient,
+			}
+
+			got, err := w.GetForDay(tt.args.ctx, tt.args.tm, tt.args.mode)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetForDay() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -120,7 +148,7 @@ func TestGetForDay(t *testing.T) {
 	}
 }
 
-func TestValidate(t *testing.T) {
+func TestWordStore_Validate(t *testing.T) {
 	type args struct {
 		ctx  context.Context
 		word string
@@ -149,7 +177,9 @@ func TestValidate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Validate(tt.args.ctx, tt.args.word); got != tt.want {
+			w := WordStore{}
+
+			if got := w.Validate(tt.args.ctx, tt.args.word); got != tt.want {
 				t.Errorf("Validate() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/words/words_test.go
+++ b/internal/words/words_test.go
@@ -16,6 +16,13 @@ func (m *mockStore) SetWord(ctx context.Context, key string, word interface{}) e
 	return nil
 }
 
+func TestNewWordStore(t *testing.T) {
+	w := NewWordStore()
+	if w == nil {
+		t.Error("Received nil for word instance")
+	}
+}
+
 func TestWordStore_GetForDay(t *testing.T) {
 	type fields struct {
 		storeClient Store

--- a/internal/words/words_test.go
+++ b/internal/words/words_test.go
@@ -103,10 +103,10 @@ func TestWordStore_GetForDay(t *testing.T) {
 			fields: fields{storeClient: &mockStore{}},
 			args: args{
 				ctx:  context.Background(),
-				tm:   time.Unix(1580083201, 0), // Mon Jan 27 00:00:01 2020 UTC
+				tm:   time.Unix(1580083201, 0).UTC(), // Mon Jan 27 00:00:01 2020 UTC
 				mode: "default",
 			},
-			want: "power",
+			want: "tell",
 		},
 		{
 			name:   "Hard mode date today",

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
 </head>
 
 <body class="mode-{{ .mode }}" data-mode="{{ .mode }}">
-  <div class="container">
+  <div id="guess-area" class="container">
     <header>
       <h1>
         <a href="/"><img src="/assets/images/logo.svg"
@@ -34,7 +34,7 @@
 
     <hr />
 
-    <div id="guess-area" class="row">
+    <div class="row">
       <div class="col-md-12">
         <ul id="after" class="list-group">
           <li class="list-group-item guess placeholder" v-if="!state.after.length">
@@ -86,7 +86,10 @@
     <div class="row">
       <div class="col-md-4">
         <p>
-          Yesterday's word: <strong>{{ .yesterday }}</strong>
+          Yesterday's word:
+          <strong id="reveal">
+            <button v-on:click.prevent="reveal" class="btn btn-info">Reveal</button>
+          </strong>
         </p>
       </div>
       <div class="col-md-4"></div>


### PR DESCRIPTION
# What

* Move the "Yesterday's Word" section behind an Ajax request so that it can extract the user's timezone.
* Convert all UTC logic to use the user's timezone, enabling more predictable word rotations (e.g. PDT timezones will get a new word at midnight rather than 5pm)
